### PR TITLE
Load accounts with empty recurring object

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -110,6 +110,7 @@ export const store = reactive({
         .eq("deleted", false);
 
       accounts.forEach((account) => {
+        account.recurring = {};
         store.accounts[account.id] = account;
       });
 
@@ -124,10 +125,6 @@ export const store = reactive({
         .eq("deleted", false);
 
       recurring.forEach((r) => {
-        if (!store.accounts[r.account_id].recurring) {
-          store.accounts[r.account_id].recurring = {};
-        }
-
         store.accounts[r.account_id].recurring[r.id] = r;
       });
 


### PR DESCRIPTION
This prevents any Object.values() errors for accounts that don't have recurring.